### PR TITLE
Update gofingerprint.go

### DIFF
--- a/cmd/gofingerprint/gofingerprint.go
+++ b/cmd/gofingerprint/gofingerprint.go
@@ -65,7 +65,7 @@ type Target struct {
 }
 
 type Worker struct {
-	JobChannel   chan *Job
+	JobChannel   chan Job
 	Fingerprints []Fingerprint
 	WorkGroup    *sync.WaitGroup
 	Colly        colly.Collector

--- a/cmd/gofingerprint/gofingerprint.go
+++ b/cmd/gofingerprint/gofingerprint.go
@@ -36,7 +36,7 @@ func NewJob(target Target, badPath string, requestMethod string, requestBody str
 		colly.MaxDepth(1),
 	)
 	collector.AllowURLRevisit = true
-	collector.WithTransport(&http.Transport{ // Add this line
+	collector.WithTransport(&http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	})
 	collector.ParseHTTPErrorResponse = true
@@ -65,13 +65,13 @@ type Target struct {
 }
 
 type Worker struct {
-	JobChannel   chan Job
+	JobChannel   chan *Job
 	Fingerprints []Fingerprint
 	WorkGroup    *sync.WaitGroup
 	Colly        colly.Collector
 }
 
-func NewWorker(jobs chan Job, fingerprints []Fingerprint, wg *sync.WaitGroup) Worker {
+func NewWorker(jobs chan *Job, fingerprints []Fingerprint, wg *sync.WaitGroup) Worker {
 	return Worker{
 		JobChannel:   jobs,
 		Fingerprints: fingerprints,
@@ -85,7 +85,7 @@ func (w Worker) Start2() {
 		for {
 			select {
 			case job := <-w.JobChannel:
-				if job == nil {
+				if job == (*Job)(nil) {
 					wgi.Done()
 					return
 				} else {

--- a/cmd/gofingerprint/gofingerprint.go
+++ b/cmd/gofingerprint/gofingerprint.go
@@ -71,7 +71,7 @@ type Worker struct {
 	Colly        colly.Collector
 }
 
-func NewWorker(jobs chan *Job, fingerprints []Fingerprint, wg *sync.WaitGroup) Worker {
+func NewWorker(jobs chan Job, fingerprints []Fingerprint, wg *sync.WaitGroup) Worker {
 	return Worker{
 		JobChannel:   jobs,
 		Fingerprints: fingerprints,

--- a/cmd/gofingerprint/gofingerprint.go
+++ b/cmd/gofingerprint/gofingerprint.go
@@ -31,6 +31,10 @@ type Job struct {
 	Collector colly.Collector
 }
 
+func (j *Job) Fetch() {
+	j.Collector.Visit(fmt.Sprintf("http://%s%s", j.Target.Domain, j.Path))
+}
+
 func NewJob(target Target, badPath string, requestMethod string, requestBody string) Job {
 	collector := colly.NewCollector(
 		colly.MaxDepth(1),

--- a/cmd/gofingerprint/gofingerprint.go
+++ b/cmd/gofingerprint/gofingerprint.go
@@ -119,6 +119,9 @@ func (w Worker) Start2() {
 
 func NewTarget(targetParts string) Target {
 	targetPieces := strings.Split(targetParts, ",")
+	if len(targetPieces) < 3 {
+		log.Fatal("Invalid target file format. Expected format: Domain,IP,Port")
+	}
 	return Target{strings.ReplaceAll(targetPieces[0], "\"", ""),
 		strings.ReplaceAll(targetPieces[1], "\"", ""),
 		strings.ReplaceAll(targetPieces[2], "\"", ""), "", "", 0, ""}

--- a/cmd/gofingerprint/gofingerprint.go
+++ b/cmd/gofingerprint/gofingerprint.go
@@ -36,7 +36,9 @@ func NewJob(target Target, badPath string, requestMethod string, requestBody str
 		colly.MaxDepth(1),
 	)
 	collector.AllowURLRevisit = true
-	collector.SetClient(&client)
+	collector.WithTransport(&http.Transport{ // Add this line
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	})
 	collector.ParseHTTPErrorResponse = true
 	collector.OnHTML("title", func(element *colly.HTMLElement) {
 		if len(element.Text) > 49 {
@@ -50,15 +52,6 @@ func NewJob(target Target, badPath string, requestMethod string, requestBody str
 		target.Body = string(response.Body)
 	})
 	return Job{&target, badPath, requestMethod, requestBody, *collector}
-}
-
-func (j Job) Fetch() {
-	targetUrl := "https://" + j.Target.Ip + ":" + j.Target.Port + j.Path
-	err := j.Collector.Visit(targetUrl)
-	if err != nil && debug {
-		fmt.Println(targetUrl)
-		fmt.Println(err)
-	}
 }
 
 type Target struct {


### PR DESCRIPTION
gofingerprint now compiles without error with go version go1.20.5 linux/amd64. I also updated an error message to be more helpful to users.
```
$ gofingerprint -fingerprints ./fingerprints.json -target /root/aol-httpx.txt 
Started 20 workers!
2023/06/21 14:55:31 Invalid target file format. Expected format: Domain,IP,Port
```
👍🏻 